### PR TITLE
Remove trailing slashes from nLab links

### DIFF
--- a/_docs/CAP_project-based/constructors.md
+++ b/_docs/CAP_project-based/constructors.md
@@ -94,9 +94,9 @@ description: Category constructors
 
 <!-- BEGIN FOOTER -->
 
-[doctrine]: https://ncatlab.org/nlab/show/doctrine/
+[doctrine]: https://ncatlab.org/nlab/show/doctrine
 
-[thin]: https://ncatlab.org/nlab/show/thin+category/
+[thin]: https://ncatlab.org/nlab/show/thin+category
 
 [CAP]: https://homalg-project.github.io/pkg/CAP/
 

--- a/_docs/CAP_project-based/doctrines.md
+++ b/_docs/CAP_project-based/doctrines.md
@@ -50,7 +50,7 @@ There are several [CAP][CAP]-based packages that define various *categorical doc
 
 <!-- BEGIN FOOTER -->
 
-[doctrine]: https://ncatlab.org/nlab/show/doctrine/
+[doctrine]: https://ncatlab.org/nlab/show/doctrine
 
 [CAP]: https://homalg-project.github.io/pkg/CAP
 

--- a/_docs/CAP_project-based/index.md
+++ b/_docs/CAP_project-based/index.md
@@ -655,6 +655,6 @@ The [CAP-based packages](#packages-part-of-or-based-on-cap_project) provide vari
 
 [Locales]: https://homalg-project.github.io/pkg/Locales
 
-[doctrine]: https://ncatlab.org/nlab/show/doctrine/
+[doctrine]: https://ncatlab.org/nlab/show/doctrine
 
 <!-- END FOOTER -->


### PR DESCRIPTION
With trailing slashes there are "AccessDenied" errors.